### PR TITLE
Document current MiniMax API configuration

### DIFF
--- a/Env-Setup.md
+++ b/Env-Setup.md
@@ -45,6 +45,31 @@ loaded = load_dotenv(find_dotenv(), override=True)
 # 从环境变量中获取 OpenAI API Key 或者直接赋值
 API_KEY = os.getenv("API_KEY")
 
-# 如果您使用的是官方 API，就直接用 https://api.siliconflow.cn/v1 就行。
-BASE_URL = "https://api.siliconflow.cn/v1"
+# Read the model settings from the environment.
+BASE_URL = os.getenv("BASE_URL")
+MODEL_NAME = os.getenv("MODEL_NAME")
 ```
+
+## MiniMax configuration reference
+
+Set `MODEL_NAME` and `BASE_URL` in `.env` when using the MiniMax API:
+
+```text
+API_KEY=your_api_key
+MODEL_NAME=MiniMax-M3
+BASE_URL=https://api.minimax.io/v1
+```
+
+Choose the endpoint that matches the account region and client protocol:
+
+| Region | OpenAI-compatible endpoint | Anthropic-compatible endpoint | Documentation |
+| --- | --- | --- | --- |
+| Global | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` | `https://platform.minimax.io/docs` |
+| China | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` | `https://platform.minimaxi.com/docs` |
+
+Current model metadata and pricing in USD per million tokens:
+
+| Model | Context window | Input modalities | Thinking modes | Input | Output | Cache read | Cache write |
+| --- | ---: | --- | --- | ---: | ---: | ---: | ---: |
+| `MiniMax-M3` | 1,000,000 | text, image, video | adaptive, disabled | $0.60 | $2.40 | $0.12 | Not listed |
+| `MiniMax-M2.7` | 204,800 | text | always on | $0.30 | $1.20 | $0.06 | $0.375 |

--- a/tests/test_minimax_configuration.py
+++ b/tests/test_minimax_configuration.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import unittest
+
+
+GUIDE = Path(__file__).resolve().parents[1] / "Env-Setup.md"
+
+
+class MiniMaxConfigurationDocumentationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+
+    def test_regional_endpoints_are_current(self):
+        for endpoint in (
+            "https://api.minimax.io/v1",
+            "https://api.minimax.io/anthropic",
+            "https://api.minimaxi.com/v1",
+            "https://api.minimaxi.com/anthropic",
+        ):
+            self.assertIn(endpoint, self.guide)
+
+    def test_model_metadata_is_current(self):
+        expected_rows = (
+            "| `MiniMax-M3` | 1,000,000 | text, image, video | adaptive, disabled | $0.60 | $2.40 | $0.12 | Not listed |",
+            "| `MiniMax-M2.7` | 204,800 | text | always on | $0.30 | $1.20 | $0.06 | $0.375 |",
+        )
+        for row in expected_rows:
+            self.assertIn(row, self.guide)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reason: Refresh the documented MiniMax endpoints and model metadata to the current configuration.

## Changes

- Document the global and China API endpoints for both supported client protocol paths.
- Record current context windows, input modalities, thinking modes, and token pricing for MiniMax-M3 and MiniMax-M2.7.
- Read the example base URL and model name from environment variables.
- Add regression coverage for the endpoint and model metadata tables.

## Checks

- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `git diff --check`
